### PR TITLE
Update frameworks, language version, and package versions

### DIFF
--- a/.github/workflows/shared_publish_workflow.yml
+++ b/.github/workflows/shared_publish_workflow.yml
@@ -30,15 +30,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET 6
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 6.0.x
-
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
 
       - name: Restore dependencies
         working-directory: ./src

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -16,15 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET 6
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 6.0.x
-
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
 
       - name: Restore dependencies
         working-directory: ./src

--- a/src/SolidCode.CombinatorialTests.Core.Tests/SolidCode.CombinatorialTests.Core.Tests.csproj
+++ b/src/SolidCode.CombinatorialTests.Core.Tests/SolidCode.CombinatorialTests.Core.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6;net8</TargetFrameworks>
-		<LangVersion>12.0</LangVersion>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<LangVersion>13.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -15,8 +15,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-		<PackageReference Include="xunit" Version="2.9.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SolidCode.CombinatorialTests.MSTest/SolidCode.CombinatorialTests.MSTest.csproj
+++ b/src/SolidCode.CombinatorialTests.MSTest/SolidCode.CombinatorialTests.MSTest.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
-		<LangVersion>12.0</LangVersion>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<LangVersion>13.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\SolidCode.CombinatorialTests.MSTest.xml</DocumentationFile>
 
 		<Title>SolidCode.CombinatorialTests.MSTest</Title>
 		<Description>Provides attbutes to generate combinatorial test data for MSTest test methods.</Description>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<Copyright>Copyright ©️ 2024 Andrey Veselov</Copyright>
 
 		<IsPackable>true</IsPackable>
@@ -28,7 +28,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SolidCode.CombinatorialTests.XUnit/SolidCode.CombinatorialTests.XUnit.csproj
+++ b/src/SolidCode.CombinatorialTests.XUnit/SolidCode.CombinatorialTests.XUnit.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
-		<LangVersion>12.0</LangVersion>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<LangVersion>13.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\SolidCode.CombinatorialTests.XUnit.xml</DocumentationFile>
 
 		<Title>SolidCode.CombinatorialTests.MSTest</Title>
 		<Description>Provides attbutes to generate combinatorial test data for xUnit test methods.</Description>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<Copyright>Copyright ©️ 2024 Andrey Veselov</Copyright>
 
 		<IsPackable>true</IsPackable>
@@ -28,7 +28,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit" Version="2.9.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Updated target frameworks: removed `net6`, added `net9.0`
- Updated language version from `12.0` to `13.0`
- Updated `Microsoft.NET.Test.Sdk` from `17.11.0` to `17.11.1`
- Updated `xunit` from `2.9.0` to `2.9.2`
- Updated `MSTest.TestFramework` from `3.5.2` to `3.6.3`
- Updated `SolidCode.CombinatorialTests` packages from `1.0.0` to `1.1.0`
- Corrected `Title` and `Description` in `SolidCode.CombinatorialTests.XUnit.csproj`