### PR TITLE
Upgrade test dependencies and increment project version

### DIFF
--- a/src/SolidCode.CombinatorialTests.Core.Tests/SolidCode.CombinatorialTests.Core.Tests.csproj
+++ b/src/SolidCode.CombinatorialTests.Core.Tests/SolidCode.CombinatorialTests.Core.Tests.csproj
@@ -15,9 +15,9 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/SolidCode.CombinatorialTests.MSTest/SolidCode.CombinatorialTests.MSTest.csproj
+++ b/src/SolidCode.CombinatorialTests.MSTest/SolidCode.CombinatorialTests.MSTest.csproj
@@ -9,7 +9,7 @@
 
 		<Title>SolidCode.CombinatorialTests.MSTest</Title>
 		<Description>Provides attbutes to generate combinatorial test data for MSTest test methods.</Description>
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 		<Copyright>Copyright ©️ 2024 Andrey Veselov</Copyright>
 
 		<IsPackable>true</IsPackable>
@@ -28,7 +28,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Updated SolidCode.CombinatorialTests.Core.Tests.csproj:
- Microsoft.NET.Test.Sdk from 17.11.1 to 17.12.0
- xunit.runner.visualstudio from 2.8.2 to 3.0.0

Updated SolidCode.CombinatorialTests.MSTest.csproj:
- Project version from 1.1.0 to 1.1.1
- MSTest.TestFramework from 3.6.3 to 3.7.0