### PR TITLE
Fix workflows error

### DIFF
--- a/.github/workflows/shared_publish_workflow.yml
+++ b/.github/workflows/shared_publish_workflow.yml
@@ -30,6 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:

--- a/src/SolidCode.CombinatorialTests.Core.Tests/SolidCode.CombinatorialTests.Core.Tests.csproj
+++ b/src/SolidCode.CombinatorialTests.Core.Tests/SolidCode.CombinatorialTests.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<LangVersion>14.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -11,11 +11,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/SolidCode.CombinatorialTests.MSTest/SolidCode.CombinatorialTests.MSTest.csproj
+++ b/src/SolidCode.CombinatorialTests.MSTest/SolidCode.CombinatorialTests.MSTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>14.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -9,7 +9,7 @@
 
 		<Title>SolidCode.CombinatorialTests.MSTest</Title>
 		<Description>Provides attbutes to generate combinatorial test data for MSTest test methods.</Description>
-		<Version>1.1.3</Version>
+		<Version>1.1.4</Version>
 		<Copyright>Copyright ©️ 2024 Andrey Veselov</Copyright>
 
 		<IsPackable>true</IsPackable>
@@ -28,8 +28,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+		<PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/SolidCode.CombinatorialTests.XUnit/SolidCode.CombinatorialTests.XUnit.csproj
+++ b/src/SolidCode.CombinatorialTests.XUnit/SolidCode.CombinatorialTests.XUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>14.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -9,7 +9,7 @@
 
 		<Title>SolidCode.CombinatorialTests.MSTest</Title>
 		<Description>Provides attbutes to generate combinatorial test data for xUnit test methods.</Description>
-		<Version>1.1.2</Version>
+		<Version>1.1.3</Version>
 		<Copyright>Copyright ©️ 2024 Andrey Veselov</Copyright>
 
 		<IsPackable>true</IsPackable>
@@ -29,7 +29,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
This pull request updates the supported .NET target frameworks and refreshes several package dependencies across the solution. It also updates the GitHub Actions workflows to ensure .NET 8 is available during CI runs. The most notable changes are the removal of .NET 9.0 as a target, dependency version bumps, and workflow improvements.

**Target Framework Updates:**

* Removed `net9.0` as a target framework from `SolidCode.CombinatorialTests.Core.Tests`, `SolidCode.CombinatorialTests.MSTest`, and `SolidCode.CombinatorialTests.XUnit` projects, so only `net8.0`, `net10.0`, and (where relevant) `netstandard2.0` remain. [[1]](diffhunk://#diff-360cf74db42f4c64c1b29ae49ea0c0bb6a2edf6b9869be5f46b5cf3a10bffccaL4-R4) [[2]](diffhunk://#diff-780b5a000dc47df0fc6c5ee7237b8557feb2ba01ce72805fe1aeb62d56874efbL4-R12) [[3]](diffhunk://#diff-8fd72ce71f07bbe3df612a2eb9df5b9fde1e3d9400bd68ba70e345fbfa680be3L4-R12)

**Dependency Updates:**

* Updated `coverlet.collector` to `10.0.1` and `Microsoft.NET.Test.Sdk` to `18.6.0` in `SolidCode.CombinatorialTests.Core.Tests.csproj`.
* Updated `MSTest.TestFramework` to `4.2.3` and `Microsoft.SourceLink.GitHub` to `10.0.300` in `SolidCode.CombinatorialTests.MSTest.csproj`.
* Updated `Microsoft.SourceLink.GitHub` to `10.0.300` in `SolidCode.CombinatorialTests.XUnit.csproj`.

**Version Bumps:**

* Bumped the package version for `SolidCode.CombinatorialTests.MSTest` to `1.1.4` and for `SolidCode.CombinatorialTests.XUnit` to `1.1.3`. [[1]](diffhunk://#diff-780b5a000dc47df0fc6c5ee7237b8557feb2ba01ce72805fe1aeb62d56874efbL4-R12) [[2]](diffhunk://#diff-8fd72ce71f07bbe3df612a2eb9df5b9fde1e3d9400bd68ba70e345fbfa680be3L4-R12)

**CI Workflow Improvements:**

* Added a step to set up .NET 8 in both `shared_publish_workflow.yml` and `test_run.yml` GitHub Actions workflows to ensure compatibility and proper environment setup during builds and tests. [[1]](diffhunk://#diff-587ebd0759c246726efc84dee67de4b849ce24c990d5d0c96e7a0a32610e4e98R33-R37) [[2]](diffhunk://#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eR19-R23)